### PR TITLE
Add languages to sample configuration

### DIFF
--- a/config/settings.sample.yml
+++ b/config/settings.sample.yml
@@ -5,3 +5,6 @@ development:
     username: root
     password:
     database: rubyconfar_development
+  languages:
+    en: English
+    es: Español


### PR DESCRIPTION
Languages were missing from sample configuration.

Not a huge deal as it is easy to fix, but now you don't have to ;)
