### PR TITLE
La vista de sponsoring en español que muestra un <DIV class "yeslver" />

### DIFF
--- a/views/sponsoring_es.haml
+++ b/views/sponsoring_es.haml
@@ -13,7 +13,7 @@
           %th.formula
             Gold
           %th.formula
-            .yeslver
+            Silver
           %th.formula
             Bronze
         %tr


### PR DESCRIPTION
La vista de sponsoring en español que muestra un DIV class "yeslver" en lugar de la palabra Silver.
En inglés la vista está OK.
